### PR TITLE
Add SpicyChai LaTeX to resume tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -360,6 +360,7 @@ This is a complete web development resource you need to build your next project.
 - [novoresume](https://novoresume.com) - Make a perfect resume in 2020 and get your dream job using the free resume builder. Select a template. Personalize it.
 - [RX-Resume](https://rx-resume.web.app) - Easily build your resume.
 - [Overleaf](https://www.overleaf.com/) - Overleaf is a LaTeX editor which can be used to create ATS friendly resumes.
+- [SpicyChai LaTeX](https://latex.spicychai.com/) - Online LaTeX editor with AI-powered template population and real-time PDF preview. Great for creating ATS friendly resumes with pre-built templates.
 - [Resume Worded](https://resumeworded.com/) - Resume Worded can be used to check whether your resume is ATS friendly or not.
 - [Open Resume](https://www.open-resume.com/) - Open Resume is an open source Resume builder and parser.
 


### PR DESCRIPTION
Adds [SpicyChai LaTeX](https://latex.spicychai.com/) alongside Overleaf in the Resume section.

SpicyChai LaTeX is an online LaTeX editor with AI-powered template population and real-time PDF preview — useful for creating ATS-friendly resumes with pre-built LaTeX templates.

**Disclosure:** I am the creator of SpicyChai LaTeX.