### PR TITLE
Add CheatGrid to Documentations and Cheatsheets section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ This is a complete web development resource you need to build your next project.
 - [CSS Grid Cheat Sheet](https://alialaa.github.io/css-grid-cheat-sheet/) - Your ultimate CSS grid visual guide.
 - [OverAPI](https://overapi.com) - Collection Of Cheat Sheets.
 - [Awesome Cheatsheets](https://lecoupa.github.io/awesome-cheatsheets/) - Awesome cheatsheets for popular programming languages, frameworks and development tools.
-- [CheatGrid](https://www.cheatgrid.com/mobile-development/0315-react-native-cheat-sheet?search=react) - Developer cheat sheets for web development, programming languages, DevOps, AI, and more.
+- [CheatGrid](https://www.cheatgrid.com/web-development/0022-react-frontend-framework-cheat-sheet?search=react) - Developer cheat sheets for web development, programming languages, DevOps, AI, and more.
 - [GitSheet](https://gitsheet.wtf) - A dead simple git cheatsheet.
 - [HTML5 Doctor](http://html5doctor.com/element-index/) - This is a quick reference of elements that are new or have been redefined in HTML5.
 - [HTML5 Canvas Cheat Sheet ](https://simon.html5.org/dump/html5-canvas-cheat-sheet.html) - HTML5 Canvas Cheat Sheet.

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,7 @@ This is a complete web development resource you need to build your next project.
 - [CSS Grid Cheat Sheet](https://alialaa.github.io/css-grid-cheat-sheet/) - Your ultimate CSS grid visual guide.
 - [OverAPI](https://overapi.com) - Collection Of Cheat Sheets.
 - [Awesome Cheatsheets](https://lecoupa.github.io/awesome-cheatsheets/) - Awesome cheatsheets for popular programming languages, frameworks and development tools.
+- [CheatGrid](https://www.cheatgrid.com/mobile-development/0315-react-native-cheat-sheet?search=react) - Developer cheat sheets for web development, programming languages, DevOps, AI, and more.
 - [GitSheet](https://gitsheet.wtf) - A dead simple git cheatsheet.
 - [HTML5 Doctor](http://html5doctor.com/element-index/) - This is a quick reference of elements that are new or have been redefined in HTML5.
 - [HTML5 Canvas Cheat Sheet ](https://simon.html5.org/dump/html5-canvas-cheat-sheet.html) - HTML5 Canvas Cheat Sheet.


### PR DESCRIPTION
Adding CheatGrid to the Documentations and Cheatsheets section, alongside OverAPI and Awesome Cheatsheets.

Link: https://www.cheatgrid.com/mobile-development/0315-react-native-cheat-sheet

Includes free cheat sheets with no account needed.