### PR TITLE
Add Jsonic (free in-browser JSON tools)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -332,6 +332,7 @@ This is a complete web development resource you need to build your next project.
 - [Insomnia](https://insomnia.rest) - Leading Open Source API Client, and Collaborative API Design Platform for GraphQL, and REST.
 - [JSON Server](https://github.com/typicode/json-server) - Get a full fake REST API with zero coding in less than 30 seconds (seriously). Created with <3 for front-end developers who need a quick back-end for prototyping and mocking.
 - [JSONing](https://jsoning.com/api/) - Instantly Mock a REST API from a JSON Object for Testing and Prototyping.
+- [Jsonic](https://jsonic.io) - Free in-browser toolkit to format, validate, and repair JSON, convert JSON to CSV/YAML/XML, and decode JWTs. No signup, runs entirely client-side.
 - [npm trends](https://www.npmtrends.com) - Which NPM package should you use? Compare NPM package download stats over time. Spot trends, pick the winner.
 - [BUNDLEPHOBIA](https://bundlephobia.com) - Find the cost of adding a npm package to your bundle.
 


### PR DESCRIPTION
Adds [Jsonic](https://jsonic.io) to the **DEVELOPER TOOLS** section.

Jsonic is a free, in-browser toolkit for JSON and web data: JSON formatter/validator/repair, JSON to CSV/YAML/XML converters, a JWT decoder, and a JSON Schema validator. No signup and everything runs client-side. It fits alongside the other hosted JSON tools already listed in that section.

One link added, in the existing format.