### PR TITLE
Add Markstream to developer tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -328,6 +328,7 @@ This is a complete web development resource you need to build your next project.
 
 ### 🛠 DEVELOPER TOOLS
 
+- [Markstream](https://markstream.simonhe.me/) - An open-source streaming Markdown renderer for AI chat interfaces, with Vue, React, Svelte, and Angular packages plus Mermaid, KaTeX, code highlighting, and safe HTML support.
 - [DevToolLab](https://devtoollab.com) - A comprehensive platform that helps developers discover and explore the best tools for their development workflow. Features tools across various categories with user reviews and recommendations.
 - [All Tools Verse](https://alltoolsverse.com/) - A searchable directory of 1,000+ free browser-based tools, including 95 developer utilities for JSON, CSS, SQL, regex, code conversion, and more. No signup required.
 - [Postman](https://www.postman.com) - Postman makes API development easy. Simplify each step of building an API and streamline collaboration so you can create better APIs—faster.


### PR DESCRIPTION
## Summary

Adds Markstream to the Developer Tools section. Markstream is an MIT-licensed streaming Markdown renderer designed for AI chat interfaces, with maintained packages for Vue, React, Svelte, and Angular.

Repository: https://github.com/Simon-He95/markstream-vue
Documentation: https://markstream.simonhe.me/
Playground: https://markstream-vue.simonhe.me/

Disclosure: I maintain Markstream and am submitting it because it fits this curated developer-tools section.