### PR TITLE
Add What Font Finder (image-based font identifier)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -146,6 +146,7 @@ This is a complete web development resource you need to build your next project.
 - [Fontjoy](https://fontjoy.com) - Fontjoy helps designers choose the best font combinations. Mix and match different fonts for the perfect pairing.
 - [FontPair](https://fontpair.co) - Font Pair helps designers pair Google Fonts together. Beautiful Google Font combinations and pairs.
 - [FontsWiki](https://fontswiki.com) - Searchable font catalog with free alternatives, pairings, and real-world fonts-in-use references.
+- [What Font Finder](https://whatfontfinder.com/font-identifier/) - Identify a font from an image in the browser, with a confidence score and no upload.
 - [Font Playground](https://play.typedetail.com) - Play with variable fonts.
 - [Font Anything](https://app.typeanything.io) - Type Anything is a free and awesome typography tool to create and test font combinations for your projects.
 


### PR DESCRIPTION
Link: https://whatfontfinder.com/font-identifier/

Adding one resource: a font identifier that works from an **image** rather than from a page's CSS — a screenshot, a poster, a logo — which is the case where you cannot just inspect the source.

Two things that distinguish it from the identifiers usually listed:

- **It runs entirely in the browser.** The image is never uploaded to a server.
- **Every match carries a confidence score**, so a close hit is distinguishable from a guess.

Free, no account, no watermark, no paid tier.

Thanks for maintaining the list.
