### PR TITLE
Add HTTP Status Codes Reference to Developer Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -335,6 +335,7 @@ This is a complete web development resource you need to build your next project.
 - [JSON Server](https://github.com/typicode/json-server) - Get a full fake REST API with zero coding in less than 30 seconds (seriously). Created with <3 for front-end developers who need a quick back-end for prototyping and mocking.
 - [JSONing](https://jsoning.com/api/) - Instantly Mock a REST API from a JSON Object for Testing and Prototyping.
 - [Jsonic](https://jsonic.io) - Free in-browser toolkit to format, validate, and repair JSON, convert JSON to CSV/YAML/XML, and decode JWTs. No signup, runs entirely client-side.
+- [HTTP Status Codes Reference](https://nutilz.com/http-status-codes) - Searchable reference for every HTTP status code (1xx-5xx) with plain-English explanations and usage guidance. Free, no signup required.
 - [Tura](https://github.com/Tura-AI/tura) - Tura is a local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it.
 - [npm trends](https://www.npmtrends.com) - Which NPM package should you use? Compare NPM package download stats over time. Spot trends, pick the winner.
 - [BUNDLEPHOBIA](https://bundlephobia.com) - Find the cost of adding a npm package to your bundle.


### PR DESCRIPTION
Adds [Nutilz HTTP Status Codes Reference](https://nutilz.com/http-status-codes) to the Developer Tools section, alongside the other free browser-based dev tools already listed there (Jsonic, JSONing, etc.).

It is a searchable reference covering every standard HTTP status code (1xx-5xx) with plain-English explanations, usage guidance, and answers to common questions (e.g. 301 vs 302, 401 vs 403, when to use 204). Free, no signup required.

Happy to adjust placement or wording if you would prefer it elsewhere.